### PR TITLE
Add min-juju-version to charm metadata

### DIFF
--- a/charms/istio-ingressgateway/metadata.yaml
+++ b/charms/istio-ingressgateway/metadata.yaml
@@ -39,3 +39,4 @@ provides:
 requires:
   istio-pilot:
     interface: http
+min-juju-version: 2.8-beta1

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -44,3 +44,4 @@ provides:
 #     interface: http
 #   istio-tracing:
 #     interface: http
+min-juju-version: 2.8-beta1


### PR DESCRIPTION
So that people don't accidentally use the current stable version