### PR TITLE
Switch to whitelist for sidecar injections

### DIFF
--- a/charms/istio-pilot/reactive/charm.py
+++ b/charms/istio-pilot/reactive/charm.py
@@ -249,17 +249,19 @@ def start_charm():
                                     }
                                 ],
                                 "failurePolicy": "Fail",
-                                "namespaceSelector": {
-                                    "matchLabels": {"istio-injection": "enabled"}
-                                },
+                                "namespaceSelector": {"matchLabels": {"juju-model": namespace}},
                                 "objectSelector": {
+                                    "matchLabels": {
+                                        "juju-app": route['service']
+                                        for route in service_mesh.routes()
+                                    },
                                     "matchExpressions": [
                                         {
                                             "key": "juju-app",
                                             "operator": "NotIn",
                                             "values": ["istio-pilot", "istio-ingressgateway"],
                                         }
-                                    ]
+                                    ],
                                 },
                             }
                         ],


### PR DESCRIPTION
This avoids injecting sidecars into things that don't really need them